### PR TITLE
Let users disable the scrolling on focus

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ts-utils",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "homepage": "https://github.com/townsquared/utils",
   "authors": [
     "Townsquared Dev"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ts-utils",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Angular Utilities for Townsqd.com",
   "main": "utils.min.js",
   "scripts": {

--- a/src/focusOn.js
+++ b/src/focusOn.js
@@ -33,11 +33,19 @@ angular.module('ts.utils')
     return {
       link: function($scope, $element, $attrs) {
         var listener = angular.noop;
+        var complete = function() {
+          $element[0].focus();
+        }
+
         $attrs.$observe('focusOn', function(newVal){
           // Stop listening to old event name
           listener();
           // Listen to new event name
           listener = $scope.$on(newVal, function(speed){
+
+            // Let users disable the scrolling effect by setting the auto-center attribute to "false"
+            if ($attrs.focusOnAutoCenter === 'false') return complete();
+
             speed = speed || 1000;
             // Center element on screen
             if($element.parents('.reveal-modal').length) {
@@ -46,10 +54,7 @@ angular.module('ts.utils')
                 scrollTop: $element.offset().top - targetWindow.offset().top + targetWindow.scrollTop()
               }, {
                 speed: speed,
-                complete: function complete() {
-                  // Focus element (if input)
-                  $element[0].focus();
-                }
+                complete: complete
               });
             }
             else {
@@ -82,10 +87,7 @@ angular.module('ts.utils')
 
               $('body').animate({ scrollTop: offset }, {
                 speed: speed,
-                complete: function complete() {
-                  // Focus element (if input)
-                  $element[0].focus();
-                }
+                complete: complete
               });
             }
           });

--- a/src/focusOn.js
+++ b/src/focusOn.js
@@ -35,7 +35,7 @@ angular.module('ts.utils')
         var listener = angular.noop;
         var complete = function() {
           $element[0].focus();
-        }
+        };
 
         $attrs.$observe('focusOn', function(newVal){
           // Stop listening to old event name
@@ -43,8 +43,11 @@ angular.module('ts.utils')
           // Listen to new event name
           listener = $scope.$on(newVal, function(speed){
 
-            // Let users disable the scrolling effect by setting the auto-center attribute to "false"
-            if ($attrs.focusOnAutoCenter === 'false') return complete();
+            // Let users disable the scrolling effect by setting the auto-center
+            // attribute to "false"
+            if ($attrs.focusOnAutoCenter === 'false') {
+              return complete();
+            }
 
             speed = speed || 1000;
             // Center element on screen


### PR DESCRIPTION
**Usage**:

``` js
<element focus-on="someValue" focus-on-auto-center="false"></element>
```

This use case came up in the new [tags ticket](https://www.pivotaltracker.com/story/show/117663891) for core product. 
